### PR TITLE
Issue #SC-961 feat: Include message and output timezone for Channel and Date parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.pinterest</groupId>
     <artifactId>secor</artifactId>
-    <version>0.24-SNAPSHOT</version>
+    <version>0.25-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>secor</name>
     <description>Kafka to s3/gs/swift logs exporter</description>
@@ -47,8 +47,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <parquet.version>1.9.0</parquet.version>

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -533,6 +533,11 @@ public class SecorConfig {
         return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
     }
 
+    public TimeZone getMessageTimeZone() {
+        String timezone = getString("secor.message.timezone");
+        return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
+    }
+
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);
     }

--- a/src/test/java/com/pinterest/secor/parser/ChannelDateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/ChannelDateMessageParserTest.java
@@ -1,0 +1,136 @@
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.TimeZone;
+
+@RunWith(PowerMockRunner.class)
+public class ChannelDateMessageParserTest extends TestCase {
+
+    private SecorConfig mConfig;
+    private Message mFormat1;
+    private Message mFormat2;
+    private Message mFormat3;
+    private Message mInvalidDate;
+    private Message mISOFormat;
+    private Message mNanosecondISOFormat;
+    private Message mNestedISOFormat;
+    private long timestamp;
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("Asia/Kolkata"));
+        Mockito.when(mConfig.getMessageTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+        Mockito.when(mConfig.isPartitionPrefixEnabled()).thenReturn(true);
+        Mockito.when(mConfig.getPartitionPrefixIdentifier()).thenReturn("eid");
+
+        timestamp = System.currentTimeMillis();
+
+        byte format1[] = "{\"timestamp\":\"2014-07-30 22:53:20\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat1 = new Message("test", 0, 0, null, format1, timestamp);
+
+        byte format2[] = "{\"timestamp\":\"2014/10/25\",\"eid\":\"IMPRESSION\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat2 = new Message("test", 0, 0, null, format2, timestamp);
+
+        byte format3[] = "{\"timestamp\":\"02001.July.04 AD 12:08 PM\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat3 = new Message("test", 0, 0, null, format3, timestamp);
+
+        byte invalidDate[] = "{\"timestamp\":\"11111111\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mInvalidDate = new Message("test", 0, 0, null, invalidDate, timestamp);
+
+        byte isoFormat[] = "{\"timestamp\":\"2006-01-02T15:04:05Z\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mISOFormat = new Message("test", 0, 0, null, isoFormat, timestamp);
+
+        byte nanosecondISOFormat[] = "{\"timestamp\":\"2006-01-02T23:59:59.999999999Z\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"}}"
+                .getBytes("UTF-8");
+        mNanosecondISOFormat = new Message("test", 0, 0, null, nanosecondISOFormat, timestamp);
+
+        byte nestedISOFormat[] = "{\"meta_data\":{\"created\":\"2016-01-11T11:50:28.647Z\"},\"eid\":\"ME_WORKFLOW_SUMMARY\",\"dimensions\":{\"channel\":\"test-channel\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mNestedISOFormat = new Message("test", 0, 0, null, nestedISOFormat, timestamp);
+    }
+
+    @Test
+    public void testExtractDateUsingInputPattern() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        assertEquals("test-channel/summary/2014-07-31", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy/MM/d");
+        assertEquals("test-channel/raw/2014-10-25", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
+        assertEquals("test-channel/summary/2001-07-04", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        assertEquals("test-channel/summary/2006-01-02", new ChannelDateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("test-channel/summary/2006-01-02", new ChannelDateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("test-channel/summary/2006-01-03", new ChannelDateMessageParser(mConfig).extractPartitions(mNanosecondISOFormat)[0]);
+    }
+
+    @Test
+    public void testExtractDateWhenPrefixIsNotSet() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.isPartitionPrefixEnabled()).thenReturn(false);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        assertEquals("test-channel/2014-07-31", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testExtractDateWithWrongEntries() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getString("secor.partition.output_dt_format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+
+        // invalid date
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
+        assertEquals("raw/" + ChannelDateMessageParser.defaultDate, new PatternDateMessageParser(
+                mConfig).extractPartitions(mInvalidDate)[0]);
+
+        // invalid pattern
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyy-MM-dd :s");
+        assertEquals("raw/" + ChannelDateMessageParser.defaultDate, new PatternDateMessageParser(
+                mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testDatePrefix() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getString("secor.partition.output_dt_format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
+
+        assertEquals("test-channel/summary/2014-07-31", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testCustomDateFormat() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+        Mockito.when(mConfig.getPartitionOutputDtFormat()).thenReturn("'yr='yyyy'/mo='MM'/dy='dd'/hr='HH");
+
+        assertEquals("test-channel/summary/yr=2014/mo=07/dy=31/hr=04", new ChannelDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+}

--- a/src/test/java/com/pinterest/secor/parser/PatternDateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/PatternDateMessageParserTest.java
@@ -1,0 +1,135 @@
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.TimeZone;
+
+@RunWith(PowerMockRunner.class)
+public class PatternDateMessageParserTest extends TestCase {
+
+    private SecorConfig mConfig;
+    private Message mFormat1;
+    private Message mFormat2;
+    private Message mFormat3;
+    private Message mInvalidDate;
+    private Message mISOFormat;
+    private Message mNanosecondISOFormat;
+    private Message mNestedISOFormat;
+    private long timestamp;
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("Asia/Kolkata"));
+        Mockito.when(mConfig.getMessageTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+        Mockito.when(mConfig.isPartitionPrefixEnabled()).thenReturn(true);
+        Mockito.when(mConfig.getPartitionPrefixIdentifier()).thenReturn("eid");
+
+        timestamp = System.currentTimeMillis();
+
+        byte format1[] = "{\"timestamp\":\"2014-07-30 22:53:20\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat1 = new Message("test", 0, 0, null, format1, timestamp);
+
+        byte format2[] = "{\"timestamp\":\"2014/10/25\",\"eid\":\"IMPRESSION\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat2 = new Message("test", 0, 0, null, format2, timestamp);
+
+        byte format3[] = "{\"timestamp\":\"02001.July.04 AD 12:08 PM\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat3 = new Message("test", 0, 0, null, format3, timestamp);
+
+        byte invalidDate[] = "{\"timestamp\":\"11111111\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mInvalidDate = new Message("test", 0, 0, null, invalidDate, timestamp);
+
+        byte isoFormat[] = "{\"timestamp\":\"2006-01-02T15:04:05Z\",\"eid\":\"ME_WORKFLOW_SUMMARY\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mISOFormat = new Message("test", 0, 0, null, isoFormat, timestamp);
+
+        byte nanosecondISOFormat[] = "{\"timestamp\":\"2006-01-02T23:59:59.999999999Z\",\"eid\":\"ME_WORKFLOW_SUMMARY\"}"
+                .getBytes("UTF-8");
+        mNanosecondISOFormat = new Message("test", 0, 0, null, nanosecondISOFormat, timestamp);
+
+        byte nestedISOFormat[] = "{\"meta_data\":{\"created\":\"2016-01-11T11:50:28.647Z\"},\"eid\":\"ME_WORKFLOW_SUMMARY\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mNestedISOFormat = new Message("test", 0, 0, null, nestedISOFormat, timestamp);
+    }
+
+    @Test
+    public void testExtractDateUsingInputPattern() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        assertEquals("summary/2014-07-31", new PatternDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy/MM/d");
+        assertEquals("raw/2014-10-25", new PatternDateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
+        assertEquals("summary/2001-07-04", new PatternDateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        assertEquals("summary/2006-01-02", new PatternDateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("summary/2006-01-02", new PatternDateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("summary/2006-01-03", new PatternDateMessageParser(mConfig).extractPartitions(mNanosecondISOFormat)[0]);
+    }
+
+    @Test
+    public void testExtractDateWhenPrefixIsNotSet() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.isPartitionPrefixEnabled()).thenReturn(false);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        assertEquals("2014-07-31", new PatternDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testExtractDateWithWrongEntries() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getString("secor.partition.output_dt_format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+
+        // invalid date
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
+        assertEquals("raw/" + PatternDateMessageParser.defaultDate, new PatternDateMessageParser(
+                mConfig).extractPartitions(mInvalidDate)[0]);
+
+        // invalid pattern
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyy-MM-dd :s");
+        assertEquals("raw/" + PatternDateMessageParser.defaultDate, new PatternDateMessageParser(
+                mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testDatePrefix() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getString("secor.partition.output_dt_format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
+
+        assertEquals("summary/2014-07-31", new PatternDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testCustomDateFormat() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getPartitionPrefixMapping()).thenReturn("{\"ME_WORKFLOW_SUMMARY\":\"summary\",\"DEFAULT\":\"raw\"}");
+        Mockito.when(mConfig.getPartitionOutputDtFormat()).thenReturn("'yr='yyyy'/mo='MM'/dy='dd'/hr='HH");
+
+        assertEquals("summary/yr=2014/mo=07/dy=31/hr=04", new PatternDateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+}


### PR DESCRIPTION
@SanthoshVasabhaktula @sowmya-dixit Please review the changes

1. Add capability to set secor.message.timezone. This will be used to parse the timestamp in the message according to the timezone set in the secor.common.properties. The default value will be UTC
2. Add capability to set timezone for the output date formatter for the secor backups in PatternDateMessageParser.java and ChannelDateMessageParser.java. The configuration property to set the output date formatter timezone is secor.parser.timezone.